### PR TITLE
Update module to support Magisk 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,29 @@ jobs:
           poetry config virtualenvs.create false
           poetry install
           python3 main.py
-          echo "NEW_TAG=$(cat NEW_TAG.txt)" >> $GITHUB_ENV
-
+          
       - name: Release
-        if: hashFiles('NEW_TAG.txt') != ''
-        uses: ncipollo/release-action@v1.10.0
+        if: env.NEW_TAG != ''
+        uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: build/*.zip
           tag: "${{ env.NEW_TAG }}"
-          body: https://github.com/frida/frida/releases
+          body: "https://github.com/frida/frida/releases"
+      
+      - name: Write update.json
+        if: env.NEW_TAG != ''
+        run: |+
+          echo '{
+               "version": "${{ env.NEW_TAG }}",
+                "versionCode": ${{ env.VERSION_CODE }},
+                "zipUrl": "https://github.com/${{ env.THIS_REPOSITORY }}/releases/download/${{ env.NEW_TAG }}/MagiskFrida-${{ env.NEW_TAG }}.zip",
+                "changelog": "https://github.com/frida/frida/releases"
+          }' > update.json
+          
+      - name: Commit update.json
+        if: env.NEW_TAG != ''
+        uses: test-room-7/action-update-file@v1.6.0
+        with:
+          file-path: update.json
+          commit-msg: Commit update.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.py
+++ b/build.py
@@ -52,10 +52,15 @@ def extract_file(archive_path: Path, dest_path: Path):
 
 
 def create_module_prop(path: Path, project_tag: str):
+    # If we are building the script via a GitHub action
+    update_json_link = f"https://raw.githubusercontent.com/{os.getenv('GITHUB_REPOSITORY')}/master/update.json"\
+        if os.getenv('GITHUB_REPOSITORY') else ""
+    
     module_prop = f"""id=magisk-frida
 name=MagiskFrida
 version={project_tag}
 versionCode={project_tag.replace(".", "").replace("-", "")}
+updateJson={update_json_link}
 author=ViRb3
 description=Run frida-server on boot"""
 

--- a/main.py
+++ b/main.py
@@ -8,15 +8,16 @@
 # 2. Checks if last commit doesn't have frida tag and is titled 'release'
 #    Yes -> must tag
 #    No  -> continue
-# If tagging, writes new tag to 'NEW_TAG.txt' and builds
+# If tagging, writes new tag to NEW_TAG and builds
 # Otherwise, does nothing and builds with placeholder tag
-# 3. Deployment will execute only if 'NEW_TAG.txt' is present
+# 3. Deployment will execute only if NEW_TAG is present
 #
 # NOTE: Requires git
 #
 
 import build
 import util
+import os
 
 
 def main():
@@ -32,12 +33,19 @@ def main():
         new_project_tag = util.get_next_revision(last_frida_tag)
         print(f"Update needed to {new_project_tag}")
 
-        # for use by deployment
-        with open("NEW_TAG.txt", "w") as the_file:
-            the_file.write(new_project_tag)
+        # Assign our environmental variables so we can write update.json
+        env_file = os.getenv("GITHUB_ENV")
+        env_contents = f"""
+NEW_TAG={new_project_tag}
+VERSION_CODE={new_project_tag.replace(".", "").replace("-", "")}
+THIS_REPOSITORY={os.getenv("GITHUB_REPOSITORY") if os.getenv("GITHUB_REPOSITORY") else ""}
+"""
+        
+        with open(env_file, "a") as env:
+            env.write(env_contents)
     else:
         print("All good!")
-
+        
     build.do_build(last_frida_tag, new_project_tag)
 
 

--- a/update.json
+++ b/update.json
@@ -1,0 +1,6 @@
+{
+     "version": "16.0.9-1",
+      "versionCode": 16091,
+      "zipUrl": "https://github.com/freyta/magisk-frida/releases/download/16.0.9-1/MagiskFrida-16.0.9-1.zip",
+      "changelog": "https://github.com/frida/frida/releases"
+}

--- a/update.json
+++ b/update.json
@@ -1,6 +1,0 @@
-{
-     "version": "16.0.9-1",
-      "versionCode": 16091,
-      "zipUrl": "https://github.com/freyta/magisk-frida/releases/download/16.0.9-1/MagiskFrida-16.0.9-1.zip",
-      "changelog": "https://github.com/frida/frida/releases"
-}


### PR DESCRIPTION
This automatically creates an update.json file which Magisk should check for updates.

I removed the use of the NEW_TAG.txt file to set the environmental variable, and instead use the main Python script. I also have set a few other variables which are used to write the JSON file such as which GitHub repository runs the action, and if none is set then it doesn't write a update URL to the module.prop.

Should fix #20 