### PR TITLE
Enable Updates via Magisk

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,6 @@ jobs:
         if: hashFiles('NEW_TAG.txt') != ''
         uses: ncipollo/release-action@v1.10.0
         with:
-          artifacts: build/*.zip
+          artifacts: build/*.zip,build/updater.json
           tag: "${{ env.NEW_TAG }}"
           body: https://github.com/frida/frida/releases

--- a/build.py
+++ b/build.py
@@ -7,6 +7,7 @@ import shutil
 import threading
 import zipfile
 import concurrent.futures
+import json
 
 import requests
 
@@ -57,7 +58,8 @@ name=MagiskFrida
 version={project_tag}
 versionCode={project_tag.replace(".", "").replace("-", "")}
 author=ViRb3
-description=Run frida-server on boot"""
+description=Run frida-server on boot
+updateJson=https://github.com/ViRb3/magisk-frida/releases/latest/updater.json"""
 
     with open(path.joinpath("module.prop"), "w", newline="\n") as f:
         f.write(module_prop)
@@ -86,6 +88,18 @@ def fill_module(arch: str, frida_tag: str, project_tag: str):
     files_dir.mkdir(exist_ok=True)
     extract_file(frida_server_path, files_dir.joinpath(f"frida-server-{arch}"))
 
+
+def create_updater_json(project_tag: str):
+    logger.info("Creating updater.json")
+    
+    updater ={
+        "version": project_tag,
+        "versionCode": int(project_tag.replace(".", "").replace("-", "")),
+        "zipUrl": f"https://github.com/ViRb3/magisk-frida/releases/download/{project_tag}/MagiskFrida-{project_tag}.zip"
+    }
+
+    with open(PATH_BUILD.joinpath("updater.json"), "w", newline="\n") as f:
+        f.write(json.dumps(updater, indent = 4))
 
 def package_module(project_tag: str):
     logger.info("Packaging module")
@@ -120,5 +134,6 @@ def do_build(frida_tag: str, project_tag: str):
     # executor.shutdown()
 
     package_module(project_tag)
+    create_updater_json(project_tag)
 
     logger.info("Done")


### PR DESCRIPTION
This PR enables the Magisk Update Property to allow updating of the Module directly from Magisk. See [Magisk Documentation for module.prop](https://topjohnwu.github.io/Magisk/guides.html#moduleprop).
The build CI will generate an updater.json file to be released alonside the zip File. The module.prop points to the latest released updater.json. The updater.json points to the specific current release to allow downloading the updated Module.zip from there.
This is similar to #31, but it doesnt need to commit to the repo from the build pipeline, instead uses the release for the updater.json
Cheers, [JM-Lemmi](https://github.com/JM-lemmi)