### PR TITLE
Fix auto update with magisk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+See [https://frida.re/news/](https://frida.re/news/) for details.

--- a/build.py
+++ b/build.py
@@ -95,7 +95,8 @@ def create_updater_json(project_tag: str):
     updater ={
         "version": project_tag,
         "versionCode": int(project_tag.replace(".", "").replace("-", "")),
-        "zipUrl": f"https://github.com/ViRb3/magisk-frida/releases/download/{project_tag}/MagiskFrida-{project_tag}.zip"
+        "zipUrl": f"https://github.com/ViRb3/magisk-frida/releases/download/{project_tag}/MagiskFrida-{project_tag}.zip",
+        "changelog": ""
     }
 
     with open(PATH_BUILD.joinpath("updater.json"), "w", newline="\n") as f:

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ def create_updater_json(project_tag: str):
         "version": project_tag,
         "versionCode": int(project_tag.replace(".", "").replace("-", "")),
         "zipUrl": f"https://github.com/ViRb3/magisk-frida/releases/download/{project_tag}/MagiskFrida-{project_tag}.zip",
-        "changelog": ""
+        "changelog": "https://raw.githubusercontent.com/ViRb3/magisk-frida/master/CHANGELOG.md"
     }
 
     with open(PATH_BUILD.joinpath("updater.json"), "w", newline="\n") as f:


### PR DESCRIPTION
`changelog` is required, even when we don't have any changelog file.

I left its value empty since only markdown content is parsed, so with something like https://frida.re/news/ the HTML code would be shown.