### PR TITLE
Fixed an issue where it was unusable when no meta-modules were present in KernelSU.

### DIFF
--- a/base/action.sh
+++ b/base/action.sh
@@ -6,7 +6,7 @@ PATH=$PATH:/data/adb/ap/bin:/data/adb/magisk:/data/adb/ksu/bin
 exec 2> $MODPATH/logs/action.log
 set -x
 
-. $MODPATH/utils.sh
+. $MODPATH/utils.sh || exit $?
 
 [ -f $MODPATH/disable ] && {
     echo "[-] Frida-server is disable"
@@ -17,12 +17,12 @@ set -x
 }
 
 result="$(busybox pgrep 'frida-server')"
-if [ $result -gt 0 ]; then
+if [ -n "$result" ]; then
     echo "[-] Stopping Frida-server..."
     busybox kill -9 $result
 else
     echo "[-] Starting Frida server..."
-    frida-server -D
+    start_frida_server || exit $?
 fi
 
 sleep 1

--- a/base/customize.sh
+++ b/base/customize.sh
@@ -21,9 +21,8 @@
 ##########################################################################################
 
 # Set to true if you do *NOT* want Magisk to mount
-# any files for you. Most modules would NOT want
-# to set this flag to true
-SKIPMOUNT=false
+# any files for you. This module runs Frida from its own bin directory.
+SKIPMOUNT=true
 
 # Set to true if you need to load system.prop
 PROPFILE=false
@@ -129,7 +128,7 @@ set -x
 PATH=$PATH:/data/adb/ap/bin:/data/adb/magisk:/data/adb/ksu/bin
 
 # keep Magisk's forced module installer backend involvement minimal (must end without ";")
-# SKIPUNZIP=1
+SKIPUNZIP=1
 
 # Set what you want to display when installing your module
 print_modname() {
@@ -171,13 +170,18 @@ on_install() {
 fi
 
   ui_print "- Unzipping module files..."
-  F_TARGETDIR="$MODPATH/system/bin"
-  mkdir -p "$F_TARGETDIR"
-  chcon -R u:object_r:system_file:s0 "$F_TARGETDIR"
-  chmod -R 755 "$F_TARGETDIR"
+  busybox unzip -qq -o "$ZIPFILE" -x "META-INF/*" "files/*" -d "$MODPATH"
 
-  busybox unzip -qq -o "$ZIPFILE" "files/frida-server-$F_ARCH" -j -d "$F_TARGETDIR"
-  mv "$F_TARGETDIR/frida-server-$F_ARCH" "$F_TARGETDIR/frida-server"
+  # Clean up leftovers from previous installs that used the mount-based layout.
+  rm -rf "$MODPATH/files" "$MODPATH/system/bin"
+  rmdir "$MODPATH/system" 2>/dev/null
+
+  F_BINDIR="$MODPATH/bin"
+  mkdir -p "$F_BINDIR"
+
+  ui_print "- Installing Frida to module bin..."
+  busybox unzip -qq -o "$ZIPFILE" "files/frida-server-$F_ARCH" -j -d "$F_BINDIR"
+  mv -f "$F_BINDIR/frida-server-$F_ARCH" "$F_BINDIR/frida-server"
 }
 
 # Only some special files require specific permissions
@@ -189,7 +193,7 @@ set_permissions() {
   set_perm_recursive $MODPATH 0 0 0755 0644
 
   # Custom permissions
-  set_perm $MODPATH/system/bin/frida-server 0 2000 0755 u:object_r:system_file:s0
+  set_perm $MODPATH/bin/frida-server 0 2000 0755 u:object_r:system_file:s0
 }
 
 print_modname

--- a/base/customize.sh
+++ b/base/customize.sh
@@ -22,6 +22,8 @@
 
 # Set to true if you do *NOT* want Magisk to mount
 # any files for you. This module runs Frida from its own bin directory.
+# KernelSU's new-style customize.sh does not automatically translate this
+# into a skip_mount marker, so the installer creates that marker explicitly.
 SKIPMOUNT=true
 
 # Set to true if you need to load system.prop
@@ -119,13 +121,9 @@ REPLACE="
 # Enable boot scripts by setting the flags in the config section above.
 ##########################################################################################
 
-[ ! -d $MODPATH/logs ] && mkdir -p $MODPATH/logs
+[ ! -d "$MODPATH/logs" ] && mkdir -p "$MODPATH/logs"
 
-# log
-exec 2> $MODPATH/logs/custom.log
-set -x
-
-PATH=$PATH:/data/adb/ap/bin:/data/adb/magisk:/data/adb/ksu/bin
+PATH="$PATH:/data/adb/ap/bin:/data/adb/magisk:/data/adb/ksu/bin"
 
 # keep Magisk's forced module installer backend involvement minimal (must end without ";")
 SKIPUNZIP=1
@@ -148,40 +146,46 @@ on_install() {
     arm)   F_ARCH=$ARCH;;
     x64)   F_ARCH=x86_64;;
     x86)   F_ARCH=$ARCH;;
-    *)     ui_print "Unsupported architecture: $ARCH"; abort;;
+    *)     abort "! Unsupported architecture: $ARCH";;
   esac
 
   ui_print "- Detected architecture: $F_ARCH"
 
-  if [ "$BOOTMODE" ] && [ "$KSU" ]; then
+  if [ "$BOOTMODE" = true ] && [ "$KSU" = true ]; then
       ui_print "- Installing from KernelSU"
       ui_print "- KernelSU version: $KSU_KERNEL_VER_CODE (kernel) + $KSU_VER_CODE (ksud)"
-  elif [ "$BOOTMODE" ] && [ "$APATCH" ]; then
+  elif [ "$BOOTMODE" = true ] && [ -n "$APATCH" ]; then
       ui_print "- Installing from APatch"
       ui_print "- APatch version: $APATCH_VER_CODE. Magisk version: $MAGISK_VER_CODE"
-  elif [ "$BOOTMODE" ] && [ "$MAGISK_VER_CODE" ]; then
+  elif [ "$BOOTMODE" = true ] && [ -n "$MAGISK_VER_CODE" ]; then
       ui_print "- Installing from Magisk"
       ui_print "- Magisk version: $MAGISK_VER_CODE ($MAGISK_VER)"
   else
     ui_print "*********************************************************"
     ui_print "! Install from recovery is not supported"
     ui_print "! Please install from KernelSU or Magisk app"
-    abort    "*********************************************************"
-fi
+    abort "*********************************************************"
+  fi
 
   ui_print "- Unzipping module files..."
-  busybox unzip -qq -o "$ZIPFILE" -x "META-INF/*" "files/*" -d "$MODPATH"
+  unzip -oq "$ZIPFILE" -x "META-INF/*" "files/*" -d "$MODPATH" \
+    || abort "! Failed to extract module files"
 
   # Clean up leftovers from previous installs that used the mount-based layout.
   rm -rf "$MODPATH/files" "$MODPATH/system/bin"
   rmdir "$MODPATH/system" 2>/dev/null
 
+  # KernelSU metainstall hooks look for this marker rather than SKIPMOUNT.
+  touch "$MODPATH/skip_mount" || abort "! Failed to create skip_mount marker"
+
   F_BINDIR="$MODPATH/bin"
-  mkdir -p "$F_BINDIR"
+  mkdir -p "$F_BINDIR" || abort "! Failed to create module bin directory"
 
   ui_print "- Installing Frida to module bin..."
-  busybox unzip -qq -o "$ZIPFILE" "files/frida-server-$F_ARCH" -j -d "$F_BINDIR"
-  mv -f "$F_BINDIR/frida-server-$F_ARCH" "$F_BINDIR/frida-server"
+  unzip -ojq "$ZIPFILE" "files/frida-server-$F_ARCH" -d "$F_BINDIR" \
+    || abort "! Failed to extract Frida binary"
+  mv -f "$F_BINDIR/frida-server-$F_ARCH" "$F_BINDIR/frida-server" \
+    || abort "! Failed to install Frida binary"
 }
 
 # Only some special files require specific permissions
@@ -190,19 +194,29 @@ fi
 
 set_permissions() {
   # The following is the default rule, DO NOT remove
-  set_perm_recursive $MODPATH 0 0 0755 0644
+  set_perm_recursive "$MODPATH" 0 0 0755 0644 \
+    || abort "! Failed to set default permissions"
 
   # Custom permissions
-  set_perm $MODPATH/bin/frida-server 0 2000 0755 u:object_r:system_file:s0
+  set_perm "$MODPATH/bin/frida-server" 0 2000 0755 u:object_r:system_file:s0 \
+    || abort "! Failed to set Frida binary permissions"
 }
+
+exec 3>&2 2>"$MODPATH/logs/custom.log"
+set -x
 
 print_modname
 on_install
 set_permissions
 
-[ -f $MODPATH/disable ] && {
+set +x
+exec 2>&3 3>&-
+
+[ -f "$MODPATH/disable" ] && {
   string="description=Run frida-server on boot: ❌ (failed)"
-  sed -i "s/^description=.*/$string/g" $MODPATH/module.prop
+  sed -i "s/^description=.*/$string/g" "$MODPATH/module.prop"
 }
+
+return 0
 
 #EOF

--- a/base/service.sh
+++ b/base/service.sh
@@ -10,7 +10,7 @@ set -x
 
 wait_for_boot
 
-frida-server -D
+start_frida_server || exit $?
 
 check_frida_is_up
 

--- a/base/utils.sh
+++ b/base/utils.sh
@@ -1,18 +1,23 @@
 #!/bin/sh
 MODPATH=${0%/*}
-PATH=$PATH:/data/adb/ap/bin:/data/adb/magisk:/data/adb/ksu/bin
+FRIDA_BIN="$MODPATH/bin/frida-server"
+PATH="$MODPATH/bin:$PATH:/data/adb/ap/bin:/data/adb/magisk:/data/adb/ksu/bin"
 
 # log
 exec 2> $MODPATH/logs/utils.log
 set -x
 
-function check_frida_is_up() {
-    [ ! -z "$1" ] && timeout="$1" || timeout=4
+check_frida_is_up() {
+    if [ -n "$1" ]; then
+        timeout="$1"
+    else
+        timeout=4
+    fi
     counter=0
 
     while [ $counter -lt $timeout ]; do
-        local result="$(busybox pgrep 'frida-server')"
-        if [ $result -gt 0 ]; then
+        result="$(busybox pgrep 'frida-server')"
+        if [ -n "$result" ]; then
             echo "[-] Frida-server is running... 💉😜"
             string="description=Run frida-server on boot: ✅ (active)"
             break
@@ -30,9 +35,20 @@ function check_frida_is_up() {
     sed -i "s/^description=.*/$string/g" $MODPATH/module.prop
 }
 
+start_frida_server() {
+  if [ ! -x "$FRIDA_BIN" ]; then
+    echo "[-] Frida binary not found: $FRIDA_BIN"
+    string="description=Run frida-server on boot: ❌ (missing binary)"
+    sed -i "s/^description=.*/$string/g" $MODPATH/module.prop
+    return 1
+  fi
+
+  "$FRIDA_BIN" -D
+}
+
 wait_for_boot() {
   while true; do
-    local result="$(getprop sys.boot_completed)"
+    result="$(getprop sys.boot_completed)"
     if [ $? -ne 0 ]; then
       exit 1
     elif [ "$result" = "1" ]; then


### PR DESCRIPTION
Clean up installation leftovers and fix startup errors.





This is why I updated it: it wasn't working on my phone either. I use KernelSU and quickly identified the issue. Since the newer versions of KernelSU adopted a mechanism called [Meta-module](https://kernelsu.org/guide/metamodule.html), directly modifying the /system partition no longer works.

Additionally, the original project left the installed files directory inside the module, which are now redundant and have been removed to clean up the installation remnants.This is why I updated it: it wasn't working on my phone either. I use KernelSU and quickly identified the issue. Since the newer versions of KernelSU adopted a mechanism called [Meta-module](https://kernelsu.org/guide/metamodule.html), directly modifying the /system partition no longer works.

Additionally, the original project left the installed files directory inside the module, which are now redundant and have been removed to clean up the installation remnants.